### PR TITLE
t/*: Sort the .dir output before examining it.

### DIFF
--- a/t/dir.t
+++ b/t/dir.t
@@ -6,21 +6,21 @@ use Test;
 use IO::Glob;
 
 {
-    my @files = glob('t/fixtures/*.md').dir;
+    my @files = glob('t/fixtures/*.md').dir.sort;
     is @files.elems, 2;
     is @files[0], 't/fixtures/bar.md'.IO;
     is @files[1], 't/fixtures/foo.md'.IO;
 }
 
 {
-    my @files = glob('fixtures/foo.*').dir('t');
+    my @files = glob('fixtures/foo.*').dir('t').sort;
     is @files.elems, 2;
     is @files[0], "t/fixtures/foo.md".IO;
     is @files[1], "t/fixtures/foo.txt".IO;
 }
 
 {
-    my @files = glob(*).dir("t/fixtures");
+    my @files = glob(*).dir("t/fixtures").sort;
     is @files.elems, 6;
     is @files[0], "t/fixtures/.".IO;
     is @files[1], "t/fixtures/..".IO;

--- a/t/iterator.t
+++ b/t/iterator.t
@@ -6,7 +6,7 @@ use Test;
 use IO::Glob;
 
 {
-    my @files = glob('t/fixtures/*.md');
+    my @files = glob('t/fixtures/*.md').sort;
     is @files.elems, 2;
     is @files[0], 't/fixtures/bar.md'.IO;
     is @files[1], 't/fixtures/foo.md'.IO;


### PR DESCRIPTION
Hi,

Thanks a lot for writing IO::Glob!

What do you think about the attached trivial patch that deals with the fact that the order that .dir() returns the filenames in is not guaranteed?

Thanks again, and keep up the great work!

G'luck,
Peter