### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -8,7 +8,7 @@
         "Andrew Sterling Hanenkamp <hanenkamp@cpan.org>",
         "Peter Pentchev <roam@ringlet.net>"
     ],
-    "license" : "Artistic 2.0",
+    "license" : "Artistic-2.0",
     "provides" : {
         "IO::Glob": "lib/IO/Glob.pm6",
         "IO::Glob::Globber": "lib/IO/Glob.pm6",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license