### PR TITLE
Avoid using deprecated flatmap method

### DIFF
--- a/lib/IO/Glob.pm6
+++ b/lib/IO/Glob.pm6
@@ -439,7 +439,7 @@ multi method ACCEPTS(IO::Path:D $path) returns Bool:D {
     self!compile-globs;
     my @parts = (~$path).split($.spec.dir-sep);
     return False unless @parts.elems == @!globbers.elems;
-    [&&] (@parts Z @!globbers).flatmap: -> ($p, $g) { $p ~~ $g };
+    [&&] (@parts Z @!globbers).map: -> ($p, $g) { $p ~~ $g };
 }
 
 proto glob(|) is export { * }


### PR DESCRIPTION
The new way to do flat maps is «@foo.map(…).flat». However, in this particular case it seems flat mapping wasn't necessary in the first place.